### PR TITLE
feat: Add quarto slide publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish Quarto Docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+     - main
+    paths:
+      - 'slides/**'
+
+jobs:
+  publish:
+    name: Build & Deploy Quarto Projects
+    runs-on: ubuntu-latest
+    container:
+      image: rocker/tidyverse:4.5.0
+    permissions:
+      contents: write
+    strategy:
+      max-parallel: 1
+      matrix:
+        QUARTO_DIR:
+          - slides
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install tinytex
+        run: quarto install tinytex
+        shell: bash
+
+      - name: Install R dependencies
+        run: install.packages(c("link", "glue", "dplyr", "sdtm.oak"))
+        shell: Rscript {0}
+
+      - name: Render Quarto Project
+        run: quarto render --output-dir _site
+        working-directory: ${{ matrix.QUARTO_DIR }}
+        shell: bash
+
+      - name: Publish ${{ matrix.QUARTO_DIR }}
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./${{ matrix.QUARTO_DIR }}/_site

--- a/slides/.gitignore
+++ b/slides/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+_site/

--- a/slides/_quarto.yml
+++ b/slides/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: website

--- a/slides/index.qmd
+++ b/slides/index.qmd
@@ -1,16 +1,16 @@
 ---
 title: "R/Pharma SDTM Workshop"
-author: 
+author:
   - Rammprasad Ganapathy (Roche/Genentench)
-date: 2024-10-29
+date: 2025-04-28
 date-format: full
-format: 
+format:
   revealjs:
     theme: solarized
     transition: convex
     background-transition: fade
-editor: 
-  markdown: 
+editor:
+  markdown:
     wrap: 72
 ---
 
@@ -126,7 +126,7 @@ Time is in Eastern Standard Time.
 ::: incremental
 
 -   v0.1.0 is avaiable on CRAN.
--  **EDC agnostic** `sdtm.oak` is designed to be highly versatile, accommodating varying raw data structures from different EDC systems and external vendors. 
+-  **EDC agnostic** `sdtm.oak` is designed to be highly versatile, accommodating varying raw data structures from different EDC systems and external vendors.
 -   **Data standards agnostic** It supports both CDISC-defined data collection standards (CDASH) and various proprietary data collection standards defined by pharmaceutical companies.
 -  Provides a framework for modular programming, making it a valuable addition to the pharmaverse ecosystem.
 
@@ -138,7 +138,7 @@ Time is in Eastern Standard Time.
 
 ::: incremental
 
--  The SDTM mappings that transform the collected source data into the target SDTM data model are grouped into algorithms. 
+-  The SDTM mappings that transform the collected source data into the target SDTM data model are grouped into algorithms.
 - These mapping algorithms form the backbone of {sdtm.oak}
 - Algorithms can be re-used across multiple SDTM domains.
 -  **Programming language agnostic** This concept does not rely on a specific programming language for implementation.
@@ -225,7 +225,7 @@ Time is in Eastern Standard Time.
 - Create SDTM derived variables
 - Add Lables and Attributes
 
-::: 
+:::
 
 # Workshop - Create CM domain
 
@@ -260,11 +260,11 @@ Did we review the following in the code?
 
 What function should be used for mapping for CMROUTE
 
-> > -   
+> > -
 > >
 > >     a)  sdtm.oak::assign_no_ct()
 > >
-> > -   
+> > -
 > >
 > >     b)  sdtm.oak::assign_ct()
 
@@ -286,11 +286,11 @@ Did we review the following in the code?
 
 When to use hardcode mapping algorithm?
 
-> > -   
+> > -
 > >
 > >     a)  To assign a collected value on the eCRF
 > >
-> > -   
+> > -
 > >
 > >     b)  To Hardcode a SDTM variable that has not directly collected on the eCRF.
 
@@ -300,7 +300,7 @@ When to use hardcode mapping algorithm?
 # Release summary
 
 ::: incremental
-- Users can create the majority of the SDTM domains. 
+- Users can create the majority of the SDTM domains.
 - **Not Supported Domains**\
       DM (Demographics)\
       EX (Exposure)\
@@ -319,7 +319,7 @@ When to use hardcode mapping algorithm?
 - Quick preview of the sdtm specifications (draft stage)
 - Showcase the potential for automation.
 
-      
+
 ## Roadmap
 We are planning to develop the below features in the subsequent releases.
 


### PR DESCRIPTION
Adds publishing of the presentation as a website hosted on GitHub Pages.
Eg: https://cicdguy.github.io/rinpharma-2024-SDTM-workshop/

After this is merged, you need to:

1. Enable `gh-pages` deployment by going to https://github.com/pharmaverse/rinpharma-2024-SDTM-workshop/settings/pages and setting the following:
![Screenshot 2025-04-24 at 8 34 14 AM](https://github.com/user-attachments/assets/f5169b15-1bc3-42fc-ae97-86b6d6af45f8)

1. Accessing the site at https://pharmaverse.github.io/rinpharma-2024-SDTM-workshop/
